### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ If you love this repository you may be interested in these projects:
 
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=9P9&repo=Website-Token-Grabber-2&show_owner=true)](https://github.com/9P9/Website-Token-Grabber-2)
 
-[![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=the-cult-of-integral&repo=discord-raidkit&show_owner=true)](https://github.com/9P9/Website-Token-Grabber-2)
+[![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=the-cult-of-integral&repo=discord-raidkit&show_owner=true)](https://github.com/the-cult-of-integral/discord-raidkit)


### PR DESCRIPTION
The link to my repo in the check out other repos section links to the 9P9 repo of the first card. This is fixed in this pull request.